### PR TITLE
allow sending of html or markdown formatted messages

### DIFF
--- a/TelegramBot/module.php
+++ b/TelegramBot/module.php
@@ -87,8 +87,8 @@ class TelegramBot extends WebHookModule
 
             // Send message
             $result = Longman\TelegramBot\Request::sendMessage([
-                'chat_id' => $NameOrChatID,
-                'text'    => $Text,
+                'chat_id'    => $NameOrChatID,
+                'text'       => $Text,
                 'parse_mode' => $parse_mode,
             ]);
 


### PR DESCRIPTION
Nachrichten die per Bot versendet werden, können per HTML oder Markdown formatiert werden.

>The Bot API supports basic formatting for messages. You can use bold, italic, underlined and strikethrough text, as well as inline links and pre-formatted code in your bots' messages. Telegram clients will render them accordingly. 


![grafik](https://user-images.githubusercontent.com/35669489/139461716-fb546805-d21c-4440-a852-060210eedc5d.png)
