### PR TITLE
Revert Standard parse mode

### DIFF
--- a/TelegramBot/module.php
+++ b/TelegramBot/module.php
@@ -82,7 +82,7 @@ class TelegramBot extends WebHookModule
             if ($Text != strip_tags($Text)) {
                 $parse_mode = 'HTML';
             } else {
-                $parse_mode = 'MarkdownV2';
+                $parse_mode = '';
             }
 
             // Send message


### PR DESCRIPTION
Standard parse mode changed back to plain text

Parse Mode war im Standard "Markdown".  
Zeichen die zur Markdown Formatierung benutzt werden, sind reserviert. Diese müssen mit backslash maskiert werden.

![grafik](https://user-images.githubusercontent.com/35669489/147493929-cfb53848-23e7-4c77-8dea-53e1e39db224.png)

Mit der Änderung kann man Formatierungen mit HTML Tags machen. Ansonsten bleibt es reiner Text.